### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 Adds a Model Context Protocol (MCP) server to the FE development server to support integration with Cursor.
 
+<a href="https://glama.ai/mcp/servers/@ESnark/blowback">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ESnark/blowback/badge" alt="Vite Server MCP server" />
+</a>
+
 ## Key Features
 
 - Integration of FE development server with MCP server


### PR DESCRIPTION
This PR adds a badge for the [Vite MCP Server](https://glama.ai/mcp/servers/@ESnark/blowback) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ESnark/blowback">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ESnark/blowback/badge" alt="Vite Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.