### PR TITLE
fix: resolve ESLint errors and bug fixes

### DIFF
--- a/.changeset/fix-lint-and-bugs.md
+++ b/.changeset/fix-lint-and-bugs.md
@@ -1,0 +1,9 @@
+---
+"blowback-context": patch
+---
+
+fix: resolve ESLint errors and bug fixes
+
+- Fix unused import and case block scope issues in context-manager
+- Fix network monitor event listener leak in browser-tools (try-finally)
+- Fix race condition in log-manager by awaiting detachCheckpointStreams()

--- a/src/managers/context-manager.ts
+++ b/src/managers/context-manager.ts
@@ -1,4 +1,4 @@
-import { chromium, firefox, webkit, Browser, Page } from 'playwright';
+import { chromium, firefox, webkit, Browser } from 'playwright';
 import { Logger } from '../utils/logger.js';
 import { getScreenshotDB } from '../db/screenshot-db.js';
 import { 
@@ -78,24 +78,25 @@ export class ContextManager {
       let cdpPort: number | undefined;
       
       switch (type) {
-        case BrowserType.CHROMIUM:
-          // For Chromium, enable CDP with specific port
-          const debugPort = headless ? undefined : this.findAvailablePort();
-          const launchOptions = { 
-            headless,
-            args: debugPort ? [`--remote-debugging-port=${debugPort}`] : []
-          };
-          browser = await chromium.launch(launchOptions);
-          cdpPort = debugPort;
-          break;
-        case BrowserType.FIREFOX:
-          browser = await firefox.launch({ headless });
-          break;
-        case BrowserType.WEBKIT:
-          browser = await webkit.launch({ headless });
-          break;
-        default:
-          throw new Error(`Unsupported browser type: ${type}`);
+      case BrowserType.CHROMIUM: {
+        // For Chromium, enable CDP with specific port
+        const debugPort = headless ? undefined : this.findAvailablePort();
+        const launchOptions = {
+          headless,
+          args: debugPort ? [`--remote-debugging-port=${debugPort}`] : []
+        };
+        browser = await chromium.launch(launchOptions);
+        cdpPort = debugPort;
+        break;
+      }
+      case BrowserType.FIREFOX:
+        browser = await firefox.launch({ headless });
+        break;
+      case BrowserType.WEBKIT:
+        browser = await webkit.launch({ headless });
+        break;
+      default:
+        throw new Error(`Unsupported browser type: ${type}`);
       }
 
       // Set CDP endpoint if debugging port was specified

--- a/src/tools/browser-tools.ts
+++ b/src/tools/browser-tools.ts
@@ -565,11 +565,13 @@ If ENABLE_BASE64 environment variable is set to 'true', also includes base64 enc
 
         browserStatus.page.on('request', requestHandler);
 
-        // Wait for specified duration
-        await new Promise(resolve => setTimeout(resolve, duration));
-
-        // Stop monitoring
-        browserStatus.page.off('request', requestHandler);
+        try {
+          // Wait for specified duration
+          await new Promise(resolve => setTimeout(resolve, duration));
+        } finally {
+          // Stop monitoring (ensure cleanup even on error)
+          browserStatus.page.off('request', requestHandler);
+        }
 
         return {
           content: [

--- a/src/tools/log-manager.ts
+++ b/src/tools/log-manager.ts
@@ -166,7 +166,7 @@ export class LogManager {
           await this.attachCheckpointStream(checkpointId);
         }
 
-        this.detachCheckpointStreams();
+        await this.detachCheckpointStreams();
       }
 
       if (checkpointId) {


### PR DESCRIPTION
## Summary
- Fix ESLint errors in context-manager (unused import, indent, case block scope)
- Fix network monitor event listener leak in browser-tools (try-finally)
- Fix race condition in log-manager by awaiting detachCheckpointStreams()

## Test plan
- [x] TypeScript build passes
- [x] ESLint errors resolved (0 errors)
- [ ] Manual test: monitor-network tool error scenarios
- [ ] Manual test: log checkpoint stream operations